### PR TITLE
change LD reference filename pattern:

### DIFF
--- a/HDL.data.wrangling.R
+++ b/HDL.data.wrangling.R
@@ -72,9 +72,9 @@ if(length(log.file) != 0){
 }
 
 LD.files <- list.files(LD.path)
-if(any(grepl(x = LD.files, pattern = "UKB_snp_counter.*"))){
-  snp_counter_file <- LD.files[grep(x = LD.files, pattern = "UKB_snp_counter.*")]
-  snp_list_file <- LD.files[grep(x = LD.files, pattern = "UKB_snp_list.*")]
+if(any(grepl(x = LD.files, pattern = ".*_snp_counter.*"))){
+  snp_counter_file <- LD.files[grep(x = LD.files, pattern = ".*_snp_counter.*")]
+  snp_list_file <- LD.files[grep(x = LD.files, pattern = ".*_snp_list.*")]
   load(file=paste(LD.path, snp_counter_file, sep = "/"))
   load(file=paste(LD.path, snp_list_file, sep = "/"))
   if("nsnps.list.imputed" %in% ls()){

--- a/HDL/R/HDL.h2.R
+++ b/HDL/R/HDL.h2.R
@@ -160,8 +160,8 @@ HDL.h2 <-
         
         ## reference sample ##
         
-        LD_rda_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, ".*rda"))]
-        LD_bim_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, ".*bim"))]
+        LD_rda_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, "_.*rda"))]
+        LD_bim_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, "_.*bim"))]
         load(file=paste(LD.path, LD_rda_file, sep = "/"))
         snps.ref.df <- read.table(paste(LD.path, LD_bim_file, sep = "/"))
         

--- a/HDL/R/HDL.rg.R
+++ b/HDL/R/HDL.rg.R
@@ -97,9 +97,9 @@ HDL.rg <-
     
     LD.files <- list.files(LD.path)
     
-    if(any(grepl(x = LD.files, pattern = "UKB_snp_counter.*"))){
-      snp_counter_file <- LD.files[grep(x = LD.files, pattern = "UKB_snp_counter.*")]
-      snp_list_file <- LD.files[grep(x = LD.files, pattern = "UKB_snp_list.*")]
+    if(any(grepl(x = LD.files, pattern = ".*_snp_counter.*"))){
+      snp_counter_file <- LD.files[grep(x = LD.files, pattern = ".*_snp_counter.*")]
+      snp_list_file <- LD.files[grep(x = LD.files, pattern = ".*_snp_list.*")]
       load(file=paste(LD.path, snp_counter_file, sep = "/"))
       load(file=paste(LD.path, snp_list_file, sep = "/"))
       if("nsnps.list.imputed" %in% ls()){
@@ -204,8 +204,8 @@ HDL.rg <-
         
         ## reference sample ##
         
-        LD_rda_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, ".*rda"))]
-        LD_bim_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, ".*bim"))]
+        LD_rda_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, "_.*rda"))]
+        LD_bim_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, "_.*bim"))]
         load(file=paste(LD.path, LD_rda_file, sep = "/"))
         snps.ref.df <- read.table(paste(LD.path, LD_bim_file, sep = "/"))
         

--- a/HDL/R/HDL.rg.parallel.R
+++ b/HDL/R/HDL.rg.parallel.R
@@ -218,8 +218,8 @@ HDL.rg.parallel <-
       piece <- info.pieces.df[i,"piece"]
       ## reference sample ##
       
-      LD_rda_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, ".*rda"))]
-      LD_bim_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, ".*bim"))]
+      LD_rda_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, "_.*rda"))]
+      LD_bim_file <- LD.files[grep(x = LD.files, pattern = paste0("chr",chr,".",piece, "_.*bim"))]
       load(file=paste(LD.path, LD_rda_file, sep = "/"))
       snps.ref.df <- read.table(paste(LD.path, LD_bim_file, sep = "/"))
       


### PR DESCRIPTION
1. remove 'UKB': UKB_snp_[counter/list].\* => .\*_snp_[counter/list].\*
2. add '\_' after piece number to avoid error (e.g. the 1st-piece match
   the 11-th piece):
   paste0("chr",chr,".",piece, ".\*[rda/bim]") => paste0("chr",chr,".",piece, "_.\*[rda/bim]")